### PR TITLE
feat: add prototype inline cache for the set/get op of object

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In addition to the relevant features and optimizations in the [TODO](https://git
 - [ ] Basic Debugger API
 - [x] Poly IC
   - [x] Self Poly IC
-  - [ ] Prototype Poly IC 
+  - [x] Prototype Poly IC 
 - [x] Replace malloc To [mimalloc](https://github.com/microsoft/mimalloc)
 - [ ] Improve The Performance Of GC
 

--- a/src/core/base.h
+++ b/src/core/base.h
@@ -90,7 +90,7 @@
 /* dump objects freed by the garbage collector */
 //#define DUMP_GC_FREE
 /* dump objects leaking when freeing the runtime */
-#define DUMP_LEAKS  1
+//#define DUMP_LEAKS  1
 /* dump memory usage before running the garbage collector */
 //#define DUMP_MEM
 //#define DUMP_OBJECTS    /* dump objects in JS_FreeContext */

--- a/src/core/base.h
+++ b/src/core/base.h
@@ -90,7 +90,7 @@
 /* dump objects freed by the garbage collector */
 //#define DUMP_GC_FREE
 /* dump objects leaking when freeing the runtime */
-//#define DUMP_LEAKS  1
+// #define DUMP_LEAKS  1
 /* dump memory usage before running the garbage collector */
 //#define DUMP_MEM
 //#define DUMP_OBJECTS    /* dump objects in JS_FreeContext */

--- a/src/core/base.h
+++ b/src/core/base.h
@@ -90,7 +90,7 @@
 /* dump objects freed by the garbage collector */
 //#define DUMP_GC_FREE
 /* dump objects leaking when freeing the runtime */
-// #define DUMP_LEAKS  1
+#define DUMP_LEAKS  1
 /* dump memory usage before running the garbage collector */
 //#define DUMP_MEM
 //#define DUMP_OBJECTS    /* dump objects in JS_FreeContext */

--- a/src/core/gc.c
+++ b/src/core/gc.c
@@ -645,9 +645,12 @@ void mark_children(JSRuntime* rt, JSGCObjectHeader* gp, JS_MarkFunc* mark_func) 
         if (b->ic) {
           for (i = 0; i < b->ic->count; i++) {
             buffer = b->ic->cache[i].buffer;
-            for (j = 0; j < IC_CACHE_ITEM_CAPACITY; j++)
+            for (j = 0; j < IC_CACHE_ITEM_CAPACITY; j++) {
               if (buffer[j].shape)
                 mark_func(rt, &buffer[j].shape->header);
+              if (buffer[j].proto)
+                mark_func(rt, &buffer[j].proto->header);
+            }
           }
         }
       }

--- a/src/core/ic.c
+++ b/src/core/ic.c
@@ -136,7 +136,7 @@ int free_ic(InlineCache *ic) {
   return 0;
 }
 
-uint32_t add_ic_slot(InlineCache *ic, JSAtom atom, JSObject *object,
+force_inline uint32_t add_ic_slot(InlineCache *ic, JSAtom atom, JSObject *object,
                      uint32_t prop_offset, JSObject* prototype) {
   int32_t i;
   uint32_t h;
@@ -253,7 +253,7 @@ int ic_delete_shape_proto_watchpoints(JSRuntime *rt, JSShape *shape, JSAtom atom
   InlineCacheRingItem *ci;
   JSShape *sh;
   p = shape->proto;
-  while(p) {
+  while(likely(p)) {
     if (p->shape->watchpoint)
       list_for_each_safe(el, el1, p->shape->watchpoint) {
         ICWatchpoint *o = list_entry(el, ICWatchpoint, link);
@@ -280,7 +280,7 @@ int ic_free_shape_proto_watchpoints(JSRuntime *rt, JSShape *shape) {
   InlineCacheRingItem *ci;
   JSShape *sh;
   p = shape->proto;
-  while(p) {
+  while(likely(p)) {
     if (p->shape->watchpoint)
       list_for_each_safe(el, el1, p->shape->watchpoint) {
         ICWatchpoint *o = list_entry(el, ICWatchpoint, link);

--- a/src/core/ic.c
+++ b/src/core/ic.c
@@ -251,6 +251,7 @@ int ic_delete_shape_proto_watchpoints(JSRuntime *rt, JSShape *shape, JSAtom atom
   JSObject *p;
   JSAtom *prop;
   InlineCacheRingItem *ci;
+  JSShape *sh;
   p = shape->proto;
   while(p) {
     if (p->shape->watchpoint)
@@ -258,7 +259,7 @@ int ic_delete_shape_proto_watchpoints(JSRuntime *rt, JSShape *shape, JSAtom atom
         ICWatchpoint *o = list_entry(el, ICWatchpoint, link);
         if (o->atom == atom) {
           ci = (InlineCacheRingItem *)o->ref;
-          shape = ci->shape;
+          sh = ci->shape;
           o->delete_callback = NULL;
           o->free_callback = NULL;
           ic_watchpoint_free_handler(rt, o->ref, o->atom);
@@ -277,13 +278,14 @@ int ic_free_shape_proto_watchpoints(JSRuntime *rt, JSShape *shape) {
   JSObject *p;
   JSAtom *prop;
   InlineCacheRingItem *ci;
+  JSShape *sh;
   p = shape->proto;
   while(p) {
     if (p->shape->watchpoint)
       list_for_each_safe(el, el1, p->shape->watchpoint) {
         ICWatchpoint *o = list_entry(el, ICWatchpoint, link);
         ci = (InlineCacheRingItem *)o->ref;
-        shape = ci->shape;
+        sh = ci->shape;
         o->delete_callback = NULL;
         o->free_callback = NULL;
         ic_watchpoint_free_handler(rt, o->ref, o->atom);

--- a/src/core/ic.h
+++ b/src/core/ic.h
@@ -70,6 +70,6 @@ force_inline JSAtom get_ic_atom(InlineCache *ic, uint32_t cache_offset) {
 
 int ic_watchpoint_delete_handler(JSRuntime* rt, intptr_t ref, void* extra_data, void* target);
 int ic_watchpoint_free_handler(JSRuntime* rt, intptr_t ref, void* extra_data);
-int ic_remove_shape_proto_watchpoints(JSRuntime *rt, JSShape *shape, JSAtom atom);
-int ic_clear_shape_proto_watchpoints(JSRuntime *rt, JSShape *shape);
+int ic_delete_shape_proto_watchpoints(JSRuntime *rt, JSShape *shape, JSAtom atom);
+int ic_free_shape_proto_watchpoints(JSRuntime *rt, JSShape *shape);
 #endif

--- a/src/core/ic.h
+++ b/src/core/ic.h
@@ -68,8 +68,8 @@ force_inline JSAtom get_ic_atom(InlineCache *ic, uint32_t cache_offset) {
   return ic->cache[cache_offset].atom;
 }
 
-int ic_watchpoint_delete_handler(JSRuntime* rt, intptr_t ref, void* extra_data, void* target);
-int ic_watchpoint_free_handler(JSRuntime* rt, intptr_t ref, void* extra_data);
+int ic_watchpoint_delete_handler(JSRuntime* rt, intptr_t ref, JSAtom atom, void* target);
+int ic_watchpoint_free_handler(JSRuntime* rt, intptr_t ref, JSAtom atom);
 int ic_delete_shape_proto_watchpoints(JSRuntime *rt, JSShape *shape, JSAtom atom);
 int ic_free_shape_proto_watchpoints(JSRuntime *rt, JSShape *shape);
 #endif

--- a/src/core/ic.h
+++ b/src/core/ic.h
@@ -68,8 +68,8 @@ force_inline JSAtom get_ic_atom(InlineCache *ic, uint32_t cache_offset) {
   return ic->cache[cache_offset].atom;
 }
 
-int ic_watchpoint_remove_callback(JSRuntime* rt, intptr_t ref, void* extra_data, void* target);
-int ic_watchpoint_clear_callback(JSRuntime* rt, intptr_t ref, void* extra_data);
+int ic_watchpoint_delete_handler(JSRuntime* rt, intptr_t ref, void* extra_data, void* target);
+int ic_watchpoint_free_handler(JSRuntime* rt, intptr_t ref, void* extra_data);
 int ic_remove_shape_proto_watchpoints(JSRuntime *rt, JSShape *shape, JSAtom atom);
 int ic_clear_shape_proto_watchpoints(JSRuntime *rt, JSShape *shape);
 #endif

--- a/src/core/object.c
+++ b/src/core/object.c
@@ -163,7 +163,7 @@ JSValue JS_GetPropertyStr(JSContext* ctx, JSValueConst this_obj, const char* pro
 JSProperty* add_property(JSContext* ctx, JSObject* p, JSAtom prop, int prop_flags) {
   JSShape *sh, *new_sh;
   sh = p->shape;
-  if (ic_remove_shape_proto_watchpoints(ctx->rt, sh, prop))
+  if (ic_delete_shape_proto_watchpoints(ctx->rt, sh, prop))
     return NULL;
   if (sh->is_hashed) {
     /* try to find an existing shape */

--- a/src/core/object.c
+++ b/src/core/object.c
@@ -1988,7 +1988,7 @@ force_inline int JS_SetPropertyInternalWithIC(JSContext* ctx, JSValueConst this_
   p = JS_VALUE_GET_OBJ(this_obj);
   offset = get_ic_prop_offset(ic, offset, p->shape, &proto);
   if (likely(offset >= 0)) {
-    if (!proto)
+    if (proto)
       goto slow_path;
     set_value(ctx, &p->prop[offset].u.value, val);
     return TRUE;

--- a/src/core/runtime.c
+++ b/src/core/runtime.c
@@ -1431,6 +1431,7 @@ void JS_SetPropertyFunctionList(JSContext* ctx, JSValueConst obj, const JSCFunct
     const JSCFunctionListEntry* e = &tab[i];
     JSAtom atom = find_atom(ctx, e->name);
     JS_InstantiateFunctionListItem(ctx, obj, atom, e);
+    JSObject *p = JS_VALUE_GET_OBJ(obj);
     JS_FreeAtom(ctx, atom);
   }
 }

--- a/src/core/runtime.c
+++ b/src/core/runtime.c
@@ -355,7 +355,7 @@ int JS_SetPrototypeInternal(JSContext* ctx, JSValueConst obj, JSValueConst proto
   if (js_shape_prepare_update(ctx, p, NULL))
     return -1;
   sh = p->shape;
-  if (ic_clear_shape_proto_watchpoints(ctx->rt, p->shape))
+  if (ic_free_shape_proto_watchpoints(ctx->rt, p->shape))
     return -1;
   if (sh->proto)
     JS_FreeValue(ctx, JS_MKPTR(JS_TAG_OBJECT, sh->proto));

--- a/src/core/runtime.c
+++ b/src/core/runtime.c
@@ -355,6 +355,8 @@ int JS_SetPrototypeInternal(JSContext* ctx, JSValueConst obj, JSValueConst proto
   if (js_shape_prepare_update(ctx, p, NULL))
     return -1;
   sh = p->shape;
+  if (ic_clear_shape_proto_watchpoints(ctx->rt, p->shape))
+    return -1;
   if (sh->proto)
     JS_FreeValue(ctx, JS_MKPTR(JS_TAG_OBJECT, sh->proto));
   sh->proto = proto;

--- a/src/core/shape.c
+++ b/src/core/shape.c
@@ -589,43 +589,35 @@ int js_shape_prepare_update(JSContext* ctx, JSObject* p, JSShapeProperty** pprs)
 }
 
 int js_shape_delete_watchpoints(JSRuntime *rt, JSShape *sh, void* target) {
-  ICWatchpoint *o, *watchpoint;
+  struct list_head *el, *el1;
   if (!sh || !sh->watchpoint)
     goto end;
-  watchpoint = sh->watchpoint;
-  while(watchpoint) {
-    o = watchpoint->next;
-    if (watchpoint->delete_callback) {
-      if (!watchpoint->delete_callback(rt, watchpoint->ref, watchpoint->atom, target)) {
-        if (o)
-          o->prev = watchpoint->prev;
-        if(watchpoint->prev)
-          watchpoint->prev->next = o;
-        else
-          sh->watchpoint = o;
-        js_free_rt(rt, watchpoint);
+  list_for_each_safe(el, el1, sh->watchpoint) {
+    ICWatchpoint *o = list_entry(el, ICWatchpoint, link);
+    if (o->delete_callback)
+      if (!o->delete_callback(rt, o->ref, o->atom, target)) {
+        list_del(el);
+        js_free_rt(rt, o);
       }
-    }
-    watchpoint = o;
   }
 end:
   return 0;
 }
 
 int js_shape_free_watchpoints(JSRuntime* rt, JSShape *sh) {
-  ICWatchpoint *o, *watchpoint;
+  struct list_head *el, *el1;
   if (!sh || !sh->watchpoint)
     goto end;
-  watchpoint = sh->watchpoint;
-  sh->watchpoint = NULL;
-  while(watchpoint) {
-    o = watchpoint;
-    watchpoint = o->next;
+  list_for_each_safe(el, el1, sh->watchpoint) {
+    ICWatchpoint *o = list_entry(el, ICWatchpoint, link);
     if (o->free_callback) {
       o->free_callback(rt, o->ref, o->atom);
-      js_free_rt(rt, o);
     }
+    list_del(el);
+    js_free_rt(rt, o);
   }
+  list_empty(sh->watchpoint);
+  js_free_rt(rt, sh->watchpoint);
 end:
   return 0;
 }
@@ -641,10 +633,11 @@ ICWatchpoint* js_shape_create_watchpoint(JSRuntime *rt, JSShape *sh, intptr_t pt
   o->atom = atom;
   o->delete_callback = remove_callback;
   o->free_callback = clear_callback;
-  if (sh->watchpoint)
-    sh->watchpoint->prev = o;
-  o->prev = NULL;
-  o->next = sh->watchpoint;
-  sh->watchpoint = o;
+  if (!sh->watchpoint) {
+    sh->watchpoint = (struct list_head *)js_malloc_rt(rt, sizeof(struct list_head));
+    init_list_head(sh->watchpoint);
+  }
+  init_list_head(&o->link);
+  list_add_tail(&o->link, sh->watchpoint);
   return o;
 }

--- a/src/core/shape.c
+++ b/src/core/shape.c
@@ -589,14 +589,14 @@ int js_shape_prepare_update(JSContext* ctx, JSObject* p, JSShapeProperty** pprs)
 }
 
 int js_shape_delete_watchpoints(JSRuntime *rt, JSShape *sh, void* target) {
-  ObjectWatchpoint *o, *watchpoint;
+  ICWatchpoint *o, *watchpoint;
   if (!sh || !sh->watchpoint)
     goto end;
   watchpoint = sh->watchpoint;
   while(watchpoint) {
     o = watchpoint->next;
     if (watchpoint->delete_callback) {
-      if (!watchpoint->delete_callback(rt, watchpoint->ref, watchpoint->extra_data, target)) {
+      if (!watchpoint->delete_callback(rt, watchpoint->ref, watchpoint->atom, target)) {
         if (o)
           o->prev = watchpoint->prev;
         if(watchpoint->prev)
@@ -613,7 +613,7 @@ end:
 }
 
 int js_shape_free_watchpoints(JSRuntime* rt, JSShape *sh) {
-  ObjectWatchpoint *o, *watchpoint;
+  ICWatchpoint *o, *watchpoint;
   if (!sh || !sh->watchpoint)
     goto end;
   watchpoint = sh->watchpoint;
@@ -622,7 +622,7 @@ int js_shape_free_watchpoints(JSRuntime* rt, JSShape *sh) {
     o = watchpoint;
     watchpoint = o->next;
     if (o->free_callback) {
-      o->free_callback(rt, o->ref, o->extra_data);
+      o->free_callback(rt, o->ref, o->atom);
       js_free_rt(rt, o);
     }
   }
@@ -630,15 +630,15 @@ end:
   return 0;
 }
 
-ObjectWatchpoint* js_shape_create_watchpoint(JSRuntime *rt, JSShape *sh, intptr_t ptr, void *extra_data,
+ICWatchpoint* js_shape_create_watchpoint(JSRuntime *rt, JSShape *sh, intptr_t ptr, JSAtom atom,
                              watchpoint_delete_callback *remove_callback,
                              watchpoint_free_callback *clear_callback) {
-  ObjectWatchpoint *o;
-  o = (ObjectWatchpoint *)js_malloc_rt(rt, sizeof(ObjectWatchpoint));
+  ICWatchpoint *o;
+  o = (ICWatchpoint *)js_malloc_rt(rt, sizeof(ICWatchpoint));
   if(unlikely(!o))
     return NULL;
   o->ref = ptr;
-  o->extra_data = extra_data;
+  o->atom = atom;
   o->delete_callback = remove_callback;
   o->free_callback = clear_callback;
   if (sh->watchpoint)

--- a/src/core/shape.c
+++ b/src/core/shape.c
@@ -590,6 +590,8 @@ int js_shape_prepare_update(JSContext* ctx, JSObject* p, JSShapeProperty** pprs)
 
 int js_shape_delete_watchpoints(JSRuntime *rt, JSShape *sh, void* target) {
   ObjectWatchpoint *o, *watchpoint;
+  if (!sh || !sh->watchpoint)
+    goto end;
   watchpoint = sh->watchpoint;
   while(watchpoint) {
     o = watchpoint->next;
@@ -600,12 +602,13 @@ int js_shape_delete_watchpoints(JSRuntime *rt, JSShape *sh, void* target) {
         if(watchpoint->prev)
           watchpoint->prev->next = o;
         else
-          sh->watchpoint = NULL;
+          sh->watchpoint = o;
         js_free_rt(rt, watchpoint);
       }
     }
     watchpoint = o;
   }
+end:
   return 0;
 }
 

--- a/src/core/shape.c
+++ b/src/core/shape.c
@@ -590,7 +590,7 @@ int js_shape_prepare_update(JSContext* ctx, JSObject* p, JSShapeProperty** pprs)
 
 int js_shape_delete_watchpoints(JSRuntime *rt, JSShape *shape, void* target) {
   struct list_head *el, *el1;
-  if (!shape || !shape->watchpoint)
+  if (unlikely(!shape || !shape->watchpoint))
     goto end;
   list_for_each_safe(el, el1, shape->watchpoint) {
     ICWatchpoint *o = list_entry(el, ICWatchpoint, link);
@@ -598,6 +598,7 @@ int js_shape_delete_watchpoints(JSRuntime *rt, JSShape *shape, void* target) {
       if (!o->delete_callback(rt, o->ref, o->atom, target)) {
         list_del(el);
         js_free_rt(rt, o);
+        break;
       }
   }
 end:
@@ -606,7 +607,7 @@ end:
 
 int js_shape_free_watchpoints(JSRuntime* rt, JSShape *shape) {
   struct list_head *el, *el1;
-  if (!shape || !shape->watchpoint)
+  if (unlikely(!shape || !shape->watchpoint))
     goto end;
   list_for_each_safe(el, el1, shape->watchpoint) {
     ICWatchpoint *o = list_entry(el, ICWatchpoint, link);

--- a/src/core/shape.c
+++ b/src/core/shape.c
@@ -588,11 +588,11 @@ int js_shape_prepare_update(JSContext* ctx, JSObject* p, JSShapeProperty** pprs)
   return 0;
 }
 
-int js_shape_delete_watchpoints(JSRuntime *rt, JSShape *sh, void* target) {
+int js_shape_delete_watchpoints(JSRuntime *rt, JSShape *shape, void* target) {
   struct list_head *el, *el1;
-  if (!sh || !sh->watchpoint)
+  if (!shape || !shape->watchpoint)
     goto end;
-  list_for_each_safe(el, el1, sh->watchpoint) {
+  list_for_each_safe(el, el1, shape->watchpoint) {
     ICWatchpoint *o = list_entry(el, ICWatchpoint, link);
     if (o->delete_callback)
       if (!o->delete_callback(rt, o->ref, o->atom, target)) {
@@ -604,11 +604,11 @@ end:
   return 0;
 }
 
-int js_shape_free_watchpoints(JSRuntime* rt, JSShape *sh) {
+int js_shape_free_watchpoints(JSRuntime* rt, JSShape *shape) {
   struct list_head *el, *el1;
-  if (!sh || !sh->watchpoint)
+  if (!shape || !shape->watchpoint)
     goto end;
-  list_for_each_safe(el, el1, sh->watchpoint) {
+  list_for_each_safe(el, el1, shape->watchpoint) {
     ICWatchpoint *o = list_entry(el, ICWatchpoint, link);
     if (o->free_callback) {
       o->free_callback(rt, o->ref, o->atom);
@@ -616,13 +616,13 @@ int js_shape_free_watchpoints(JSRuntime* rt, JSShape *sh) {
     list_del(el);
     js_free_rt(rt, o);
   }
-  list_empty(sh->watchpoint);
-  js_free_rt(rt, sh->watchpoint);
+  list_empty(shape->watchpoint);
+  js_free_rt(rt, shape->watchpoint);
 end:
   return 0;
 }
 
-ICWatchpoint* js_shape_create_watchpoint(JSRuntime *rt, JSShape *sh, intptr_t ptr, JSAtom atom,
+ICWatchpoint* js_shape_create_watchpoint(JSRuntime *rt, JSShape *shape, intptr_t ptr, JSAtom atom,
                              watchpoint_delete_callback *remove_callback,
                              watchpoint_free_callback *clear_callback) {
   ICWatchpoint *o;
@@ -633,11 +633,11 @@ ICWatchpoint* js_shape_create_watchpoint(JSRuntime *rt, JSShape *sh, intptr_t pt
   o->atom = atom;
   o->delete_callback = remove_callback;
   o->free_callback = clear_callback;
-  if (!sh->watchpoint) {
-    sh->watchpoint = (struct list_head *)js_malloc_rt(rt, sizeof(struct list_head));
-    init_list_head(sh->watchpoint);
+  if (!shape->watchpoint) {
+    shape->watchpoint = (struct list_head *)js_malloc_rt(rt, sizeof(struct list_head));
+    init_list_head(shape->watchpoint);
   }
   init_list_head(&o->link);
-  list_add_tail(&o->link, sh->watchpoint);
+  list_add_tail(&o->link, shape->watchpoint);
   return o;
 }

--- a/src/core/shape.h
+++ b/src/core/shape.h
@@ -89,9 +89,9 @@ JSValue JS_NewObjectFromShape(JSContext* ctx, JSShape* sh, JSClassID class_id);
 int js_shape_prepare_update(JSContext* ctx, JSObject* p, JSShapeProperty** pprs);
 
 /* the watch point of shape for prototype inline cache or something else */
-int js_shape_delete_watchpoints(JSRuntime *rt, JSShape *sh, void* target);
-int js_shape_free_watchpoints(JSRuntime *rt, JSShape *sh);
-ICWatchpoint* js_shape_create_watchpoint(JSRuntime *rt, JSShape *sh, intptr_t ptr, JSAtom atom,
+int js_shape_delete_watchpoints(JSRuntime *rt, JSShape *shape, void* target);
+int js_shape_free_watchpoints(JSRuntime *rt, JSShape *shape);
+ICWatchpoint* js_shape_create_watchpoint(JSRuntime *rt, JSShape *shape, intptr_t ptr, JSAtom atom,
                              watchpoint_delete_callback *remove_callback,
                              watchpoint_free_callback *clear_callback);
 

--- a/src/core/shape.h
+++ b/src/core/shape.h
@@ -89,10 +89,10 @@ JSValue JS_NewObjectFromShape(JSContext* ctx, JSShape* sh, JSClassID class_id);
 int js_shape_prepare_update(JSContext* ctx, JSObject* p, JSShapeProperty** pprs);
 
 /* the watch point of shape for prototype inline cache or something else */
-int js_shape_remove_watchpoints(JSRuntime *rt, JSShape *sh, void* target);
-int js_shape_clear_watchpoints(JSRuntime *rt, JSShape *sh);
+int js_shape_delete_watchpoints(JSRuntime *rt, JSShape *sh, void* target);
+int js_shape_free_watchpoints(JSRuntime *rt, JSShape *sh);
 ObjectWatchpoint* js_shape_create_watchpoint(JSRuntime *rt, JSShape *sh, intptr_t ptr, void *extra_data,
-                             watchpoint_remove_callback *remove_callback,
-                             watchpoint_clear_callback *clear_callback);
+                             watchpoint_delete_callback *remove_callback,
+                             watchpoint_free_callback *clear_callback);
 
 #endif

--- a/src/core/shape.h
+++ b/src/core/shape.h
@@ -88,4 +88,11 @@ JSValue JS_NewObjectFromShape(JSContext* ctx, JSShape* sh, JSClassID class_id);
 /* ensure that the shape can be safely modified */
 int js_shape_prepare_update(JSContext* ctx, JSObject* p, JSShapeProperty** pprs);
 
+/* the watch point of shape for prototype inline cache or something else */
+int js_shape_remove_watchpoints(JSRuntime *rt, JSShape *sh, void* target);
+int js_shape_clear_watchpoints(JSRuntime *rt, JSShape *sh);
+ObjectWatchpoint* js_shape_create_watchpoint(JSRuntime *rt, JSShape *sh, intptr_t ptr, void *extra_data,
+                             watchpoint_remove_callback *remove_callback,
+                             watchpoint_clear_callback *clear_callback);
+
 #endif

--- a/src/core/shape.h
+++ b/src/core/shape.h
@@ -91,7 +91,7 @@ int js_shape_prepare_update(JSContext* ctx, JSObject* p, JSShapeProperty** pprs)
 /* the watch point of shape for prototype inline cache or something else */
 int js_shape_delete_watchpoints(JSRuntime *rt, JSShape *sh, void* target);
 int js_shape_free_watchpoints(JSRuntime *rt, JSShape *sh);
-ObjectWatchpoint* js_shape_create_watchpoint(JSRuntime *rt, JSShape *sh, intptr_t ptr, void *extra_data,
+ICWatchpoint* js_shape_create_watchpoint(JSRuntime *rt, JSShape *sh, intptr_t ptr, JSAtom atom,
                              watchpoint_delete_callback *remove_callback,
                              watchpoint_free_callback *clear_callback);
 

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -520,9 +520,23 @@ typedef enum JSFunctionKindEnum {
     JS_FUNC_ASYNC_GENERATOR = (JS_FUNC_GENERATOR | JS_FUNC_ASYNC),
 } JSFunctionKindEnum;
 
+typedef int watchpoint_remove_callback(JSRuntime* rt, intptr_t ref, void* extra_data, void* target);
+typedef int watchpoint_clear_callback(JSRuntime* rt, intptr_t ref, void* extra_data);
+
+typedef struct ObjectWatchpoint {
+    intptr_t ref;
+    void *extra_data;
+    watchpoint_remove_callback *remove_callback;
+    watchpoint_clear_callback *clear_callback;
+    struct ObjectWatchpoint *prev;
+    struct ObjectWatchpoint *next;
+} ObjectWatchpoint;
+
 typedef struct InlineCacheRingItem {
-    JSShape* shape;
+    JSObject* proto;
+    JSShape *shape;
     uint32_t prop_offset;
+    ObjectWatchpoint *watchpoint_ref;
 } InlineCacheRingItem;
 
 typedef struct InlineCacheRingSlot {
@@ -830,6 +844,7 @@ struct JSShape {
     int deleted_prop_count;
     JSShape *shape_hash_next; /* in JSRuntime.shape_hash[h] list */
     JSObject *proto;
+    ObjectWatchpoint *watchpoint;
     JSShapeProperty prop[0]; /* prop_size elements */
 };
 

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -520,14 +520,14 @@ typedef enum JSFunctionKindEnum {
     JS_FUNC_ASYNC_GENERATOR = (JS_FUNC_GENERATOR | JS_FUNC_ASYNC),
 } JSFunctionKindEnum;
 
-typedef int watchpoint_remove_callback(JSRuntime* rt, intptr_t ref, void* extra_data, void* target);
-typedef int watchpoint_clear_callback(JSRuntime* rt, intptr_t ref, void* extra_data);
+typedef int watchpoint_delete_callback(JSRuntime* rt, intptr_t ref, void* extra_data, void* target);
+typedef int watchpoint_free_callback(JSRuntime* rt, intptr_t ref, void* extra_data);
 
 typedef struct ObjectWatchpoint {
     intptr_t ref;
     void *extra_data;
-    watchpoint_remove_callback *remove_callback;
-    watchpoint_clear_callback *clear_callback;
+    watchpoint_delete_callback *delete_callback;
+    watchpoint_free_callback *free_callback;
     struct ObjectWatchpoint *prev;
     struct ObjectWatchpoint *next;
 } ObjectWatchpoint;

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -528,8 +528,7 @@ typedef struct ICWatchpoint {
     JSAtom atom;
     watchpoint_delete_callback *delete_callback;
     watchpoint_free_callback *free_callback;
-    struct ICWatchpoint *prev;
-    struct ICWatchpoint *next;
+    struct list_head link;
 } ICWatchpoint;
 
 typedef struct InlineCacheRingItem {
@@ -844,7 +843,7 @@ struct JSShape {
     int deleted_prop_count;
     JSShape *shape_hash_next; /* in JSRuntime.shape_hash[h] list */
     JSObject *proto;
-    ICWatchpoint *watchpoint;
+    struct list_head *watchpoint;
     JSShapeProperty prop[0]; /* prop_size elements */
 };
 

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -520,23 +520,23 @@ typedef enum JSFunctionKindEnum {
     JS_FUNC_ASYNC_GENERATOR = (JS_FUNC_GENERATOR | JS_FUNC_ASYNC),
 } JSFunctionKindEnum;
 
-typedef int watchpoint_delete_callback(JSRuntime* rt, intptr_t ref, void* extra_data, void* target);
-typedef int watchpoint_free_callback(JSRuntime* rt, intptr_t ref, void* extra_data);
+typedef int watchpoint_delete_callback(JSRuntime* rt, intptr_t ref, JSAtom atom, void* target);
+typedef int watchpoint_free_callback(JSRuntime* rt, intptr_t ref, JSAtom atom);
 
-typedef struct ObjectWatchpoint {
+typedef struct ICWatchpoint {
     intptr_t ref;
-    void *extra_data;
+    JSAtom atom;
     watchpoint_delete_callback *delete_callback;
     watchpoint_free_callback *free_callback;
-    struct ObjectWatchpoint *prev;
-    struct ObjectWatchpoint *next;
-} ObjectWatchpoint;
+    struct ICWatchpoint *prev;
+    struct ICWatchpoint *next;
+} ICWatchpoint;
 
 typedef struct InlineCacheRingItem {
     JSObject* proto;
     JSShape *shape;
     uint32_t prop_offset;
-    ObjectWatchpoint *watchpoint_ref;
+    ICWatchpoint *watchpoint_ref;
 } InlineCacheRingItem;
 
 typedef struct InlineCacheRingSlot {
@@ -844,7 +844,7 @@ struct JSShape {
     int deleted_prop_count;
     JSShape *shape_hash_next; /* in JSRuntime.shape_hash[h] list */
     JSObject *proto;
-    ObjectWatchpoint *watchpoint;
+    ICWatchpoint *watchpoint;
     JSShapeProperty prop[0]; /* prop_size elements */
 };
 


### PR DESCRIPTION
For mircobenchmark, it will be about 20~30% improvement compared to previous.
```javascript
function A() { };
A.prototype.name = 'A';

let o = new A();
for (let i = 0; i < 5; i++) {
  const T = function () { };
  T.prototype = o;
  o = new T();
}

function B() { }
B.prototype = o;

const obj = new B();
const t = Date.now();
for (let i = 0; i < 1000000; i++) {
  obj.name;
}
print(Date.now() - t);
```
In approximately 2-3% improvement in `V8 Benchmark Suits`. Although not a huge improvement, it will help a lot with operations related to deeper inheritance such as DOM/BOM.