### PR TITLE
fix: optimize mimalloc dependency management

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vendor/mimalloc"]
 	path = vendor/mimalloc
 	url = https://github.com/microsoft/mimalloc
-	branch = v1.8.2
+	branch = master


### PR DESCRIPTION
## Background

mimalloc branch v1.8.2 was removed, causing the execution of `git submodule update --remote` to fail

```
fatal: Unable to find refs/remotes/origin/v1.8.2 revision in submodule path 'vendor/mimalloc'
```
## Solution

1. branch specifies the master branch.
    - master: latest stable release (based on dev-slice). [link](https://github.com/microsoft/mimalloc/tree/db3d8485d2f45a6f179d784f602f9eff4f60795c?tab=readme-ov-file#branches)
2. update the submodule method:
    1. `git submodule update --remote --recursive`.
    2. push the vendor/mimalloc folder changes.
3. just run the following commands during development:
    1. `git submodule update --init --recursive`, It will pull the commit from step 2.

## CI and Testing

1. github action for the `david-clang:fix/gitmodules` branch [link](https://github.com/david-clang/webf-quickjs/commit/5d24594f6ea7865e99fdcdfabd2dc1575f27870f)
2. test262 no error, [link](https://github.com/david-clang/webf-quickjs/actions/runs/12414817302/job/34659732869)
    - `Submodule path 'vendor/mimalloc': checked out '2765ec93026f445cad8f38e6b196dd226a1f6e61'` It stands for testing with branch master(v2.1.7) .
